### PR TITLE
Fix setup version notation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ setup(name='target-hdfs',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['target_hdfs'],
       install_requires=[
-          "singer-python>=5.13.0<6.0.0",
-          "pyarrow>=10.0.1<11.0.0"
+          "singer-python>=5.13.0,<6.0.0",
+          "pyarrow>=10.0.1,<11.0.0"
       ],
       extras_require={"dev": ["pytest<8.0.0", "pandas<2.0.0", "pylint<3.0.0", "pylint-quotes<1.0.0"]},
       entry_points='''


### PR DESCRIPTION
The package notation is missing a comma between the versions limit.