### PR TITLE
Fix: Upload more than one file with the same name (in case of multiple parquet files saved)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "target-hdfs"
-version = "1.0.0"
+version = "1.0.1"
 description = "`target-hdfs` is a Singer target for hdfs, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Joao Amaral <joao.amaral@automattic.com>"]

--- a/target_hdfs/sinks.py
+++ b/target_hdfs/sinks.py
@@ -62,8 +62,8 @@ class HDFSSink(ParquetSink):
             upload_to_hdfs(file, hdfs_file_path)
             Path(file).unlink()
 
-        # Reset hdfs_file_path to None after uploading (no file to append)
-        self.hdfs_file_path = None
+            # Reset hdfs_file_path to None after uploading the first file (no file to append)
+            self.hdfs_file_path = None
 
     def write_file(self) -> None:
         """Write a local file and upload to hdfs."""

--- a/target_hdfs/utils/parquet.py
+++ b/target_hdfs/utils/parquet.py
@@ -2,10 +2,12 @@ import os
 
 
 def get_parquet_files(dir_path: str) -> list[str]:
-    """Return the path of parquet files in the local directory."""
-    return [
-        os.path.join(root, file)
-        for root, dirs, files in os.walk(dir_path)
-        for file in files
-        if file.endswith(".parquet")
-    ]
+    """Return the sorted list of paths of parquet files in the local directory."""
+    return sorted(
+        [
+            os.path.join(root, file)
+            for root, dirs, files in os.walk(dir_path)
+            for file in files
+            if file.endswith(".parquet")
+        ]
+    )

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from target_hdfs.sinks import HDFSSink
+from target_hdfs.target import TargetHDFS
+
+
+@patch('target_hdfs.sinks.len', return_value=1)
+@patch(
+    'target_hdfs.sinks.get_parquet_files',
+    return_value=[
+        'output/test_stream/file1.parquet',
+        'output/test_stream/file2.parquet',
+    ],
+)
+@patch('target_hdfs.sinks.read_most_recent_file', return_value=None)
+@patch('target_hdfs.sinks.Path.unlink', return_value=None)
+@patch('target_hdfs.sinks.upload_to_hdfs', return_value=None)
+def test_upload_files(
+    mock_upload_to_hdfs: MagicMock,
+    mock_unlink,
+    mock_read_most_recent_file,
+    mock_get_parquet_files,
+    mock_len,
+):
+    sink = HDFSSink(
+        target=TargetHDFS(
+            config={'hdfs_destination_path': '/hdfs/path', 'skip_existing_files': False}
+        ),
+        stream_name="test_stream",
+        schema={'properties': {}},
+        key_properties=[],
+    )
+    sink.hdfs_file_path = '/hdfs/path/test_stream/file.parquet'
+    sink.upload_files()
+    mock_upload_to_hdfs.assert_any_call(
+        'output/test_stream/file1.parquet', '/hdfs/path/test_stream/file.parquet'
+    )
+    mock_upload_to_hdfs.assert_any_call(
+        'output/test_stream/file2.parquet', '/hdfs/path/test_stream/file2.parquet'
+    )

--- a/tests/utils/test_parquet.py
+++ b/tests/utils/test_parquet.py
@@ -1,0 +1,38 @@
+import os
+import tempfile
+
+import pytest
+
+from target_hdfs.utils.parquet import get_parquet_files
+
+
+@pytest.fixture
+def temp_parquet_files():
+    # Create a temporary directory and temporary parquet files for testing
+    temp_dir = tempfile.TemporaryDirectory()
+    temp_files = [
+        "file2.parquet",
+        "file1.parquet",
+        "file3.csv",  # This file should not be included in the result
+        "file4.txt",  # This file should not be included in the result
+    ]
+    for temp_file in temp_files:
+        with open(os.path.join(temp_dir.name, temp_file), "w") as f:
+            f.write("test")
+    yield temp_dir
+    # Cleanup: Close and remove the temporary directory and files
+    temp_dir.cleanup()
+
+
+def test_get_parquet_files(temp_parquet_files):
+    # Get the list of parquet files from the temporary directory
+    parquet_files = get_parquet_files(temp_parquet_files.name)
+
+    # Expected list of parquet files
+    expected_files = [
+        os.path.join(temp_parquet_files.name, "file1.parquet"),
+        os.path.join(temp_parquet_files.name, "file2.parquet"),
+    ]
+
+    # Assert that the retrieved parquet files match the expected list
+    assert parquet_files == expected_files


### PR DESCRIPTION
This issue will not happen since we raise an exception in case of multiple files. But since the pyarrow can save more than one file in case of millions of row. It's nice to allow this option in the future.