### PR TITLE
Add check for modified files loaded from HDFS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "target-hdfs"
-version = "1.0.2"
+version = "1.0.3"
 description = "`target-hdfs` is a Singer target for hdfs, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Joao Amaral <joao.amaral@automattic.com>"]

--- a/target_hdfs/sinks.py
+++ b/target_hdfs/sinks.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from target_parquet.sinks import ParquetSink
 
 from target_hdfs.utils.hdfs import (
+    get_hdfs_modified_datetime,
     read_most_recent_file,
     upload_to_hdfs,
 )
@@ -39,6 +40,7 @@ class HDFSSink(ParquetSink):
             else None
         ) or {}
         self.hdfs_file_path = hdfs_file.get("path")
+        self.hdfs_file_modified = hdfs_file.get("modified")
         # pyarrow_df is used by target-parquet (super class) as a temporary storage for the data
         # (updated on every batch where it is converted from a list of records to a pyarrow table)
         self.pyarrow_df = hdfs_file.get("content")
@@ -51,6 +53,15 @@ class HDFSSink(ParquetSink):
             raise CanNotUploadFileError(
                 "Multiple files were found in the local path, "
                 "but only one HDFS file was loaded."
+            )
+
+        if (
+            self.hdfs_file_path
+            and get_hdfs_modified_datetime(self.hdfs_file_path)
+            != self.hdfs_file_modified
+        ):
+            raise CanNotUploadFileError(
+                "The HDFS file was modified after it was loaded."
             )
 
         self.logger.debug(f"Uploading {local_parquet_files} to HDFS")

--- a/target_hdfs/sinks.py
+++ b/target_hdfs/sinks.py
@@ -61,7 +61,7 @@ class HDFSSink(ParquetSink):
             != self.hdfs_file_modified
         ):
             raise CanNotUploadFileError(
-                "The HDFS file was modified after it was loaded."
+                f"The HDFS file {self.hdfs_file_path} was modified after it was loaded."
             )
 
         self.logger.debug(f"Uploading {local_parquet_files} to HDFS")

--- a/target_hdfs/utils/hdfs.py
+++ b/target_hdfs/utils/hdfs.py
@@ -4,12 +4,15 @@ import logging
 from functools import cache
 from subprocess import run
 from tempfile import NamedTemporaryFile
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 import pyarrow as pa
 from pyarrow._fs import FileInfo, FileType
 
 from target_hdfs.utils import convert_size_to_bytes
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +26,7 @@ class HDFSFile(TypedDict):
 
     content: pa.Table
     path: str
+    modified: datetime
 
 
 @cache
@@ -88,6 +92,12 @@ def get_most_recent_file(hdfs_path: str) -> FileInfo | None:
     return max(files, key=lambda file: file.mtime) if files else None
 
 
+def get_hdfs_modified_datetime(hdfs_file_path: str) -> datetime | None:
+    """Return the modified datetime of the HDFS file."""
+    hdfs_client = get_hdfs_client()
+    return hdfs_client.get_file_info(hdfs_file_path).mtime
+
+
 def read_most_recent_file(
     hdfs_file_path: str,
     pyarrow_schema: pa.Schema,
@@ -107,6 +117,10 @@ def read_most_recent_file(
 
     with NamedTemporaryFile("wb") as tmp_file:
         download_from_hdfs(most_recent_file.path, tmp_file.name)
+        logger.info(
+            f"Reading the most recent file in hdfs: {most_recent_file.path} "
+            f"last modified: {most_recent_file.mtime}"
+        )
         parquet_df = pa.parquet.read_table(tmp_file.name)
         if set(parquet_df.schema).symmetric_difference(set(pyarrow_schema)):
             raise SchemaChangedError(
@@ -118,4 +132,8 @@ def read_most_recent_file(
         if not parquet_df.schema.equals(pyarrow_schema):
             logger.info("Rearranging columns to match the schema")
             parquet_df = parquet_df.select(pyarrow_schema.names)
-        return {"content": parquet_df, "path": most_recent_file.path}
+        return {
+            "content": parquet_df,
+            "path": most_recent_file.path,
+            "modified": most_recent_file.mtime,
+        }


### PR DESCRIPTION
This PR will avoid losing data in case two different extractions update the files after loading the same hdfs file.


Tests:
```
target_hdfs.sinks.CanNotUploadFileError: The HDFS file **** was modified after it was loaded.
```